### PR TITLE
addded apache2.2-common to package installs in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y apt-transport-https ca-certificates
 RUN echo 'deb https://oss-binaries.phusionpassenger.com/apt/passenger jessie main' > /etc/apt/sources.list.d/passenger.list
 RUN git clone https://github.com/ivaldi/brimir /opt/brimir
 WORKDIR /opt/brimir
-RUN apt-get update && apt-get -y install nodejs postgresql postgresql-client pwgen libapache2-mod-passenger
+RUN apt-get update && apt-get -y install apache2.2-common nodejs postgresql postgresql-client pwgen libapache2-mod-passenger
 RUN a2enmod passenger && apache2ctl restart
 RUN bundle install --without sqlite mysql development test --deployment
 #RUN /etc/init.d/postgresql start


### PR DESCRIPTION
I received an error when building the docker image that a2enmod did not exist. After installing apache2.2-common the build ran without error.
